### PR TITLE
Replace Handsontable demo with TUI Grid

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+npm ci

--- a/README.md
+++ b/README.md
@@ -248,3 +248,5 @@ Modern browsers and Internet Explorer 10+.
 [MIT](https://github.com/PanJiaChen/vue-element-admin/blob/master/LICENSE)
 
 Copyright (c) 2017-present PanJiaChen
+
+更多信息参见 [docs/handsontable.md](docs/handsontable.md)。

--- a/docs/handsontable.md
+++ b/docs/handsontable.md
@@ -1,0 +1,5 @@
+# 自研表格实现说明
+
+本项目未直接引用官方 Handsontable 库。出于许可与定制需求，我们基于 MIT 许可的 [TUI Grid](https://github.com/nhn/tui.grid) 编写了示例表格组件，以展示类似 Handsontable 的功能。
+
+与官方 Handsontable 相比，当前实现仅覆盖基础编辑、排序、筛选等常见场景。诸如拖拽填充、复杂条件格式、批注等高级特性尚未完全实现。如需完整的 Handsontable 功能，请考虑重新集成官方库并遵循其商业授权协议。

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import legacy from './.eslintrc.js'
+delete legacy.root
+export default legacy

--- a/package.json
+++ b/package.json
@@ -69,7 +69,12 @@
     "serve-static": "1.13.2",
     "svg-sprite-loader": "4.1.3",
     "svgo": "1.2.0",
-    "vue-template-compiler": "2.6.10"
+    "vue-template-compiler": "2.6.10",
+    "jest": "^29.7.0",
+    "vue-jest": "^5.0.0",
+    "@vue/test-utils": "^2.2.0",
+    "jest-transform-stub": "^2.0.0",
+    "jest-serializer-vue": "^2.0.0"
   },
   "eslintConfig": {
     "root": true,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import { createRouter, createWebHashHistory } from 'vue-router'
 import chartsRouter from './modules/charts'
 import tableRouter from './modules/table'
 import nestedRouter from './modules/nested'
+import gridDemoRouter from './modules/grid-demo'
 
 /**
  * Note: sub-menu only appear when route children.length >= 1
@@ -182,6 +183,7 @@ export const asyncRoutes = [
   chartsRouter,
   nestedRouter,
   tableRouter,
+  gridDemoRouter,
 
   {
     path: '/example',

--- a/src/router/modules/grid-demo.js
+++ b/src/router/modules/grid-demo.js
@@ -1,0 +1,16 @@
+/** Route for grid demo using TUI Grid */
+
+const gridDemoRouter = {
+  path: '/grid-demo',
+  component: () => import('@/layout/index'),
+  children: [
+    {
+      path: 'index',
+      component: () => import('@/views/grid-demo/index'),
+      name: 'GridDemo',
+      meta: { title: 'Grid Demo', icon: 'table' }
+    }
+  ]
+}
+
+export default gridDemoRouter

--- a/src/views/grid-demo/index.vue
+++ b/src/views/grid-demo/index.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="app-container grid-demo">
+    <div ref="grid"></div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GridDemo',
+  mounted() {
+    this.loadGridAssets().then(() => {
+      this.initGrid()
+    })
+  },
+  beforeUnmount() {
+    if (this.gridInstance) {
+      this.gridInstance.destroy()
+    }
+  },
+  methods: {
+    loadGridAssets() {
+      return new Promise(resolve => {
+        const css = document.createElement('link')
+        css.rel = 'stylesheet'
+        css.href = 'https://uicdn.toast.com/tui-grid/latest/tui-grid.css'
+        document.head.appendChild(css)
+
+        const script = document.createElement('script')
+        script.src = 'https://uicdn.toast.com/tui-grid/latest/tui-grid.umd.js'
+        script.onload = resolve
+        document.head.appendChild(script)
+      })
+    },
+    initGrid() {
+      const { Grid } = window.tui
+      this.gridInstance = new Grid({
+        el: this.$refs.grid,
+        data: [
+          { id: 1, name: 'Alice', age: 25, active: true },
+          { id: 2, name: 'Bob', age: 30, active: false }
+        ],
+        rowHeaders: ['rowNum'],
+        columns: [
+          { header: 'ID', name: 'id', editor: 'text', sortable: true },
+          { header: 'Name', name: 'name', editor: 'text', sortable: true },
+          { header: 'Age', name: 'age', editor: 'text', sortable: true, filter: 'number' },
+          { header: 'Active', name: 'active', editor: 'checkbox', sortable: true }
+        ],
+        summary: {
+          height: 40,
+          position: 'bottom',
+          columnContent: {
+            age: {
+              template(valueMap) {
+                return 'Avg: ' + (valueMap.avg || 0)
+              }
+            }
+          }
+        }
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.grid-demo {
+  overflow: auto;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- replace Handsontable demo with a TUI Grid example and new router module
- document why the project does not include the official Handsontable library
- add setup script for installing dependencies automatically
- add eslint.config.js and Jest devDependencies

## Testing
- `npm run lint` *(fails: parserOptions key not supported in flat config)*
- `npm run test:unit` *(fails: jest not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.